### PR TITLE
Entity and Setup Tests, Card Fix

### DIFF
--- a/src/main/java/data_access/APIDataAccessObject.java
+++ b/src/main/java/data_access/APIDataAccessObject.java
@@ -8,12 +8,13 @@ import okhttp3.Response;
 import org.json.JSONException;
 import org.json.JSONObject;
 import use_case.freePlayMode.FreePlayDA;
+import use_case.freeplay.setup.SetupDeckDataAccessInterface;
 
 import java.io.IOException;
 
 import static api.APIConstants.*;
 
-public class APIDataAccessObject implements FreePlayDA {
+public class APIDataAccessObject implements FreePlayDA, SetupDeckDataAccessInterface {
     /**
      * @param deckID is the ID of the current deck in play
      * @return Card object of the new card

--- a/src/main/java/data_access/GameDataAccessObject.java
+++ b/src/main/java/data_access/GameDataAccessObject.java
@@ -4,13 +4,14 @@ import entities.Dealer;
 import entities.Player;
 import entities.UserPlayer;
 import use_case.freeplay.GameDataAccess;
+import use_case.freeplay.setup.SetupGameDataAccessInterface;
 
 import java.util.ArrayList;
 
 /**
  * Game Data woohoo
  */
-public class GameDataAccessObject implements GameDataAccess {
+public class GameDataAccessObject implements GameDataAccess, SetupGameDataAccessInterface {
     UserPlayer userPlayer;
     Dealer dealer;
     ArrayList<Player> computerPlayers;

--- a/src/main/java/data_access/GameDataAccessObject.java
+++ b/src/main/java/data_access/GameDataAccessObject.java
@@ -17,6 +17,8 @@ public class GameDataAccessObject implements GameDataAccess, SetupGameDataAccess
     ArrayList<Player> computerPlayers;
     String deckID;
 
+    public GameDataAccessObject() {}
+
     public GameDataAccessObject(UserPlayer userPlayer, Dealer dealer, String deckID, ArrayList<Player> computerPlayers) {
         this.userPlayer = userPlayer;
         this.dealer = dealer;

--- a/src/main/java/entities/Card.java
+++ b/src/main/java/entities/Card.java
@@ -6,11 +6,11 @@ import java.util.ArrayList;
  * Represents a card with a rank, suit, value, and visibility status.
  */
 public class Card {
-    private String rank;
-    private String suit;
+    final private String rank;
+    final private String suit;
     private int value;
     private boolean isVisible;
-    private String image;
+    final private String image;
 
     public Card(String rank, String suit, String image) {
         this.suit = suit;

--- a/src/main/java/entities/Card.java
+++ b/src/main/java/entities/Card.java
@@ -1,7 +1,5 @@
 package entities;
 
-import java.util.ArrayList;
-
 /**
  * Represents a card with a rank, suit, value, and visibility status.
  */

--- a/src/main/java/entities/Card.java
+++ b/src/main/java/entities/Card.java
@@ -14,8 +14,8 @@ public class Card {
 
     public Card(String rank, String suit, String image) {
         this.suit = suit;
-        this.rank = rank.substring(0, 1).toUpperCase();
-        isVisible = false;
+        this.rank = rank;
+        isVisible = true;
         this.image = image;
 
         if (this.rank.equals("J") || this.rank.equals("Q") || this.rank.equals("K")) {

--- a/src/main/java/use_case/freeplay/setup/SetupDeckDataAccessInterface.java
+++ b/src/main/java/use_case/freeplay/setup/SetupDeckDataAccessInterface.java
@@ -11,7 +11,7 @@ public interface SetupDeckDataAccessInterface {
      * Draws a card from the API deck.
      * @return card drawn from the API deck.
      */
-    Card getCard();
+    Card getCard(String deckID);
 
     /**
      * Provides the DeckID from the API deck.

--- a/src/main/java/use_case/freeplay/setup/SetupGameDataAccessInterface.java
+++ b/src/main/java/use_case/freeplay/setup/SetupGameDataAccessInterface.java
@@ -1,0 +1,28 @@
+package use_case.freeplay.setup;
+
+import entities.Dealer;
+import entities.UserPlayer;
+
+/**
+ * The DAO for the Setup Use Case in the context of the GameDataAccessObject
+ */
+public interface SetupGameDataAccessInterface {
+
+    /**
+     * Sets the dealer in the DAO
+     * @param dealer the dealer of the game
+     */
+    void setDealer(Dealer dealer);
+
+    /**
+     * Sets the userPlayer in the DAO
+     * @param userPlayer the userPlayer of the game
+     */
+    void setPlayer(UserPlayer userPlayer);
+
+    /**
+     * Sets the deckID in the DAO
+     * @param deckID the deckID of the game
+     */
+    void setDeckID(String deckID);
+}

--- a/src/main/java/use_case/freeplay/setup/SetupInteractor.java
+++ b/src/main/java/use_case/freeplay/setup/SetupInteractor.java
@@ -14,9 +14,9 @@ import java.util.ArrayList;
 public class SetupInteractor implements SetupInputBoundary {
     private final SetupDeckDataAccessInterface deckDataObject;
     private final SetupOutputBoundary setupPresenter;
-    private final GameDataAccessObject gameDataObject;
+    private final SetupGameDataAccessInterface gameDataObject;
 
-    public SetupInteractor(GameDataAccessObject gameDataAccessObject,
+    public SetupInteractor(SetupGameDataAccessInterface gameDataAccessObject,
                            SetupDeckDataAccessInterface setupDeckDataAccessInterface,
                            SetupOutputBoundary setupPresenter) {
         this.gameDataObject = gameDataAccessObject;

--- a/src/main/java/use_case/freeplay/setup/SetupInteractor.java
+++ b/src/main/java/use_case/freeplay/setup/SetupInteractor.java
@@ -1,9 +1,7 @@
 package use_case.freeplay.setup;
 
-import data_access.GameDataAccessObject;
 import entities.Card;
 import entities.Dealer;
-import entities.User;
 import entities.UserPlayer;
 
 import java.util.ArrayList;
@@ -28,11 +26,11 @@ public class SetupInteractor implements SetupInputBoundary {
     public void execute() {
         String deckID = deckDataObject.getDeckID();
 
-        ArrayList<Card> userPlayerHand = new ArrayList<Card>();
+        ArrayList<Card> userPlayerHand = new ArrayList<>();
         userPlayerHand.add(deckDataObject.getCard(deckID));
         userPlayerHand.add(deckDataObject.getCard(deckID));
 
-        ArrayList<Card> dealerHand = new ArrayList<Card>();
+        ArrayList<Card> dealerHand = new ArrayList<>();
         dealerHand.add(deckDataObject.getCard(deckID));
         dealerHand.add(deckDataObject.getCard(deckID));
 
@@ -43,8 +41,8 @@ public class SetupInteractor implements SetupInputBoundary {
         UserPlayer userPlayer = new UserPlayer(userPlayerHand);
 
         //Creates the lists that hold the strings for the image links for the cards.
-        ArrayList<String> userPlayerHandLinks = new ArrayList<String>();
-        ArrayList<String> dealerHandLinks = new ArrayList<String>();
+        ArrayList<String> userPlayerHandLinks = new ArrayList<>();
+        ArrayList<String> dealerHandLinks = new ArrayList<>();
 
         for (Card card : dealer.getHand()) {
             dealerHandLinks.add(card.getImage());

--- a/src/main/java/use_case/freeplay/setup/SetupInteractor.java
+++ b/src/main/java/use_case/freeplay/setup/SetupInteractor.java
@@ -29,12 +29,12 @@ public class SetupInteractor implements SetupInputBoundary {
         String deckID = deckDataObject.getDeckID();
 
         ArrayList<Card> userPlayerHand = new ArrayList<Card>();
-        userPlayerHand.add(deckDataObject.getCard());
-        userPlayerHand.add(deckDataObject.getCard());
+        userPlayerHand.add(deckDataObject.getCard(deckID));
+        userPlayerHand.add(deckDataObject.getCard(deckID));
 
         ArrayList<Card> dealerHand = new ArrayList<Card>();
-        dealerHand.add(deckDataObject.getCard());
-        dealerHand.add(deckDataObject.getCard());
+        dealerHand.add(deckDataObject.getCard(deckID));
+        dealerHand.add(deckDataObject.getCard(deckID));
 
         //Creates hidden card
         dealerHand.getFirst().setVisible(false);

--- a/src/main/java/use_case/freeplay/setup/SetupOutputData.java
+++ b/src/main/java/use_case/freeplay/setup/SetupOutputData.java
@@ -27,6 +27,6 @@ public class SetupOutputData {
 
     public ArrayList<String> getDealerHand() {return this.dealerHand;}
 
-    public ArrayList<String> getUserPlayer() {return this.userPlayerHand;}
+    public ArrayList<String> getUserPlayerHand() {return this.userPlayerHand;}
 
 }

--- a/src/main/java/use_case/freeplay/setup/SetupOutputData.java
+++ b/src/main/java/use_case/freeplay/setup/SetupOutputData.java
@@ -1,10 +1,5 @@
 package use_case.freeplay.setup;
 
-
-import entities.Card;
-import entities.Dealer;
-import entities.UserPlayer;
-
 import java.util.ArrayList;
 
 /**

--- a/src/test/java/entities/CardTest.java
+++ b/src/test/java/entities/CardTest.java
@@ -1,0 +1,93 @@
+package entities;
+
+import org.junit.Test;
+
+import java.util.Objects;
+
+public class CardTest {
+
+    /**
+     * Tests if the card will return the correct rank by default.
+     */
+    @Test
+    public void RankTest() {
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert(card.getRank().equals("10"));
+    }
+
+    /**
+     * Tests if the card will return the correct suit by default.
+     * Remove when if/when we remove the suit.
+     */
+    @Test
+    public void SuitTest() {
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert (Objects.equals(card.getSuit(), "Hearts"));
+    }
+
+    /**
+     * Tests if the card will return the correct value by default when input is an ACE.
+     */
+    @Test
+    public void ValueATest() {
+        Card card = new Card("A", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert (card.getValue() == 11);
+    }
+
+    /**
+     * Tests if the card will return the correct value by default when input is a JACK, QUEEN, or KING.
+     */
+    @Test
+    public void ValueJTest() {
+        Card card = new Card("J", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert (card.getValue() == 10);
+    }
+
+    /**
+     * Tests if the card will return the correct value by default when input is a number rank.
+     */
+    @Test
+    public void ValueIntTest() {
+        Card card = new Card("5", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert (card.getValue() == 5);
+    }
+
+    /**
+     * Tests if the card's value will be correctly changed if an Ace's value is set to 1 from 11.
+     */
+    @Test
+    public void SetValueSuccessTest() {
+        Card card = new Card("A", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        card.setValue(1);
+        assert (card.getValue() == 1);
+    }
+
+    /**
+     * Tests if the card's value will not be changed if it is not an Ace, keeping it at its previous value.
+     */
+    @Test
+    public void SetValueFailureTest() {
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        card.setValue(1);
+        assert (card.getValue() == 10);
+    }
+
+    /**
+     * Tests if the card's visibility is corrected changed by setVisible.
+     */
+    @Test
+    public void VisibilityTest() {
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        card.setVisible(false);
+        assert (!card.isVisible());
+    }
+
+    /**
+     * Tests if the image is correctly stored and returned.
+     */
+    @Test
+    public void ImageTest() {
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+        assert (Objects.equals(card.getImage(), "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+    }
+}

--- a/src/test/java/entities/DealerTest.java
+++ b/src/test/java/entities/DealerTest.java
@@ -1,0 +1,61 @@
+package entities;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class DealerTest {
+
+    /**
+     * Tests if the dealer can correctly have hand set.
+     * This is not really a good test example.
+     */
+    @Test
+    public void DealerSetHandTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand2 = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        hand2.add(new Card("J", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand2.add(new Card("Q", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        Dealer dealer = new Dealer(hand);
+        dealer.setHand(hand2);
+
+        assert(dealer.getHand().equals(hand2));
+    }
+
+    /**
+     * Tests whether inherited player method getScore tabulates total value correctly
+     * Does NOT set aces to equal to 1, that's the hit use case's responsibility.
+     */
+    @Test
+    public void DealerGetScoreTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        Dealer dealer = new Dealer(hand);
+        assert(dealer.getScore() == 21);
+    }
+
+    /**
+     * Tests whether inherited player method hit, draws a card correctly
+     */
+    @Test
+    public void DealerHitTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+
+        Dealer dealer = new Dealer(hand);
+        dealer.hit(card);
+
+        assert(dealer.getHand().size() == 3);
+    }
+}

--- a/src/test/java/entities/DealerTest.java
+++ b/src/test/java/entities/DealerTest.java
@@ -12,8 +12,8 @@ public class DealerTest {
      */
     @Test
     public void DealerSetHandTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
-        ArrayList<Card> hand2 = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
+        ArrayList<Card> hand2 = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
@@ -33,7 +33,7 @@ public class DealerTest {
      */
     @Test
     public void DealerGetScoreTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
@@ -47,7 +47,7 @@ public class DealerTest {
      */
     @Test
     public void DealerHitTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));

--- a/src/test/java/entities/UserPlayerTest.java
+++ b/src/test/java/entities/UserPlayerTest.java
@@ -12,8 +12,8 @@ public class UserPlayerTest {
      */
     @Test
     public void UserPlayerSetHandTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
-        ArrayList<Card> hand2 = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
+        ArrayList<Card> hand2 = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
@@ -33,7 +33,7 @@ public class UserPlayerTest {
      */
     @Test
     public void UserPlayerGetScoreTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
@@ -47,7 +47,7 @@ public class UserPlayerTest {
      */
     @Test
     public void UserPlayerHitTest() {
-        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand = new ArrayList<>();
 
         hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
         hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));

--- a/src/test/java/entities/UserPlayerTest.java
+++ b/src/test/java/entities/UserPlayerTest.java
@@ -1,0 +1,61 @@
+package entities;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class UserPlayerTest {
+
+    /**
+     * Tests if the userPlayer can correctly have hand set.
+     * This is not really a good test example.
+     */
+    @Test
+    public void UserPlayerSetHandTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+        ArrayList<Card> hand2 = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        hand2.add(new Card("J", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand2.add(new Card("Q", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        UserPlayer userPlayer = new UserPlayer(hand);
+        userPlayer.setHand(hand2);
+
+        assert(userPlayer.getHand().equals(hand2));
+    }
+
+    /**
+     * Tests whether inherited player method getScore tabulates total value correctly
+     * Does NOT set aces to equal to 1, that's the hit use case's responsibility.
+     */
+    @Test
+    public void UserPlayerGetScoreTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+
+        UserPlayer userPlayer = new UserPlayer(hand);
+        assert(userPlayer.getScore() == 21);
+    }
+
+    /**
+     * Tests whether inherited player method hit, draws a card correctly
+     */
+    @Test
+    public void UserPlayerHitTest() {
+        ArrayList<Card> hand = new ArrayList<Card>();
+
+        hand.add(new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        hand.add(new Card("A", "Spades", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png"));
+        Card card = new Card("10", "Hearts", "https://wiki.tf2classic.com/w/images/f/f4/Backpack_Sandvich.png");
+
+        UserPlayer userPlayer = new UserPlayer(hand);
+        userPlayer.hit(card);
+
+        assert(userPlayer.getHand().size() == 3);
+    }
+}

--- a/src/test/java/use_cases/setup_use_case/SetupInteractorTest.java
+++ b/src/test/java/use_cases/setup_use_case/SetupInteractorTest.java
@@ -2,8 +2,6 @@ package use_cases.setup_use_case;
 
 import data_access.APIDataAccessObject;
 import data_access.GameDataAccessObject;
-import entities.Dealer;
-import entities.UserPlayer;
 import org.junit.jupiter.api.Test;
 import use_case.freeplay.setup.*;
 

--- a/src/test/java/use_cases/setup_use_case/SetupInteractorTest.java
+++ b/src/test/java/use_cases/setup_use_case/SetupInteractorTest.java
@@ -1,0 +1,83 @@
+package use_cases.setup_use_case;
+
+import data_access.APIDataAccessObject;
+import data_access.GameDataAccessObject;
+import entities.Dealer;
+import entities.UserPlayer;
+import org.junit.jupiter.api.Test;
+import use_case.freeplay.setup.*;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SetupInteractorTest {
+
+    /**
+     * Tests whether the dealer's hand's image links are empty or not. Must be 2 cards.
+     */
+    @Test
+    void linkDealerTest() {
+        SetupDeckDataAccessInterface deckRepository = new APIDataAccessObject();
+        SetupGameDataAccessInterface gameRepository = new GameDataAccessObject();
+
+        SetupOutputBoundary successPresenter = new SetupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SetupOutputData outputData) {
+
+                boolean allStrings = true;
+                for (Object obj : outputData.getDealerHand()) {
+                    if (!(obj instanceof String)) {
+                        allStrings = false;
+                        break;
+                    }
+                }
+
+                assert allStrings;
+                assertEquals(2, outputData.getDealerHand().size());
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail("Failure, unfortunate");
+            }
+        };
+
+        SetupInputBoundary interactor = new SetupInteractor(gameRepository, deckRepository, successPresenter);
+        interactor.execute();
+    }
+
+    /**
+     * Tests whether the userPlayer's hand's image links are empty or not. Must be 2 cards.
+     */
+    @Test
+    void linkUserPlayerTest() {
+        SetupDeckDataAccessInterface deckRepository = new APIDataAccessObject();
+        SetupGameDataAccessInterface gameRepository = new GameDataAccessObject();
+
+        SetupOutputBoundary successPresenter = new SetupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SetupOutputData outputData) {
+
+                boolean allStrings = true;
+                for (Object obj : outputData.getUserPlayerHand()) {
+                    if (!(obj instanceof String)) {
+                        allStrings = false;
+                        break;
+                    }
+                }
+
+                assert allStrings;
+                assertEquals(2, outputData.getUserPlayerHand().size());
+            }
+
+            @Override
+            public void prepareFailView(String errorMessage) {
+                fail("Failure, unfortunate");
+            }
+        };
+
+        SetupInputBoundary interactor = new SetupInteractor(gameRepository, deckRepository, successPresenter);
+        interactor.execute();
+    }
+
+}


### PR DESCRIPTION
**Additions**
- SetupInteractorTest
- CardTest
- UserPlayerTest
- DealerTest
- SetupGameDataAccessInterface, DAO for the GameDataObject for the Setup

**Changes**
- GameDataAccessObject can now be constructed without those unneeded parameters, very useful for testing.
- Typo Corrections here and there
- Removed unnecessary imports

Cards:
- isVisible is now true by default.
- Removed code which turns a "jack" input (for example) into "J" for the card entity's purposes. Unneeded and mucks up 10.
- Certain unchangeable card attributes set as final

**Issues**
- Not sure I did my interaction test correctly, does implement everything in output data but not enough in the actual code itself. Will ask on Piazza or Ofifce hours
- Do we need a suit attribute? It feels pointless since we just have an image link.
- Do we need to change the image link ever? Do none visible cards still have their visible versions as their links?
- Can I remove the GameDataAccessObject constructer with 4 parameters? Is anyone using that constructor?
- Since a lot of our use cases align, should we be using the same interface to reference the GameDataObject and APIDeckObject?