### PR TITLE
Setup use case of Free Play mode w/ front and back end integration

### DIFF
--- a/src/main/java/interface_adapter/freePlay/hit/HitState.java
+++ b/src/main/java/interface_adapter/freePlay/hit/HitState.java
@@ -1,0 +1,4 @@
+package interface_adapter.freeplay.hit;
+
+public class HitState {
+}

--- a/src/main/java/interface_adapter/freePlay/hit/HitViewModel.java
+++ b/src/main/java/interface_adapter/freePlay/hit/HitViewModel.java
@@ -1,0 +1,10 @@
+package interface_adapter.freeplay.hit;
+
+import interface_adapter.ViewModel;
+import interface_adapter.freeplay.hit.HitState;
+
+public class HitViewModel extends ViewModel<HitState> {
+    public HitViewModel() {
+        super("hit");
+    }
+}

--- a/src/main/java/interface_adapter/freePlay/setup/SetupController.java
+++ b/src/main/java/interface_adapter/freePlay/setup/SetupController.java
@@ -1,4 +1,27 @@
 package interface_adapter.freeplay.setup;
 
+import use_case.freeplay.setup.SetupInputBoundary;
+
 public class SetupController {
+    private final SetupInputBoundary setupInteractor;
+
+    public SetupController(SetupInputBoundary setupInteractor) {
+        this.setupInteractor = setupInteractor;
+    }
+
+    public void execute_setup() {
+        setupInteractor.execute();
+    }
+
+    public void switchToHitView() {
+        setupInteractor.switchToHitView();
+    }
+
+    public void switchToDealerAfterStandView() {
+        setupInteractor.switchToDealerAfterStandView();
+    }
+
+    public void switchToMainMenuView() {
+        setupInteractor.switchToMainMenuView();
+    }
 }

--- a/src/main/java/interface_adapter/freePlay/setup/SetupPresenter.java
+++ b/src/main/java/interface_adapter/freePlay/setup/SetupPresenter.java
@@ -1,30 +1,92 @@
 package interface_adapter.freeplay.setup;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.freeplay.hit.HitViewModel;
+import interface_adapter.freeplay.stand.FreePlayStandViewModel;
+import interface_adapter.main_menu.MainMenuViewModel;
 import interface_adapter.team_use_case.TeamViewModel;
 import use_case.freeplay.setup.SetupOutputBoundary;
 import use_case.freeplay.setup.SetupOutputData;
 
+import java.util.ArrayList;
+
 /**
  * The Presenter for the Setup Use Case.
  */
-public class SetupPresenter implements SetupOutputBoundary {
-    private TeamViewModel teamViewModel;
-    private ViewManagerModel viewManagerModel;
 
-    public SetupPresenter(ViewManagerModel viewManagerModel, TeamViewModel teamViewModel) {
+public class SetupPresenter implements SetupOutputBoundary {
+    private final ViewManagerModel viewManagerModel;
+    SetupViewModel setupViewModel;
+    HitViewModel hitViewModel;
+    FreePlayStandViewModel freePlayStandViewModel;
+    MainMenuViewModel mainMenuViewModel;
+
+    public SetupPresenter(ViewManagerModel viewManagerModel) {
         this.viewManagerModel = viewManagerModel;
-        this.teamViewModel = teamViewModel;
     }
 
+    /**
+     * Prepares success view for setup
+     *
+     * @param outputData the output data from interactor
+     */
     @Override
     public void prepareSuccessView(SetupOutputData outputData) {
-        teamViewModel.firePropertyChanged("dealer");
-        teamViewModel.firePropertyChanged("player");
+        ArrayList<String> dealerHand = outputData.getDealerHand();
+        ArrayList<String> playerHand = outputData.getUserPlayerHand();
+        final SetupState setupState = setupViewModel.getState();
+
+        setupState.setDealerCardOne(dealerHand.get(0));
+        setupState.setDealerCardTwo(dealerHand.get(1));
+        setupState.setPlayerCardOne(playerHand.get(0));
+        setupState.setPlayerCardTwo(playerHand.get(1));
+
+        setupViewModel.setState(setupState);
+        setupViewModel.firePropertyChanged();
+
+        viewManagerModel.setState(setupViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+
     }
 
-    //TODO delete I think? Can't fail currently
     @Override
-    public void prepareFailView(String error) {
+    public void prepareFailView(String errorMessage) {
+
     }
+
+    @Override
+    public void switchToHitView() {
+        viewManagerModel.setState(hitViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+    @Override
+    public void switchToDealerAfterStandView() {
+        viewManagerModel.setState(freePlayStandViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+    @Override
+    public void switchToMainMenuView() {
+        viewManagerModel.setState(mainMenuViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+
+//    /**
+//     * Fail view aka bust
+//     *
+//     * @param message explanation for why bust
+//     */
+//    @Override
+//    public void prepareBustView(String message) {
+//
+//    }
+//
+//    /**
+//     * @param message
+//     */
+//    @Override
+//    public void prepareExitView(String message) {
+//
+//    }
 }

--- a/src/main/java/interface_adapter/freePlay/setup/SetupState.java
+++ b/src/main/java/interface_adapter/freePlay/setup/SetupState.java
@@ -1,0 +1,33 @@
+package interface_adapter.freeplay.setup;
+
+public class SetupState {
+    private String dealerCardOne="";
+    private String dealerCardTwo="";
+    private String playerCardOne="";
+    private String playerCardTwo="";
+
+    public String getDealerCardOne(){
+        return dealerCardOne;
+    }
+    public String getDealerCardTwo(){
+        return dealerCardTwo;
+    }
+    public String getPlayerCardOne(){
+        return playerCardOne;
+    }
+    public String getPlayerCardTwo(){
+        return playerCardTwo;
+    }
+    public void setDealerCardOne(String firstDealerCard){
+        this.dealerCardOne=firstDealerCard;
+    }
+    public void setDealerCardTwo(String secondDealerCard){
+        this.dealerCardTwo=secondDealerCard;
+    }
+    public void setPlayerCardOne(String firstPlayerCard){
+        this.playerCardOne=firstPlayerCard;
+    }
+    public void setPlayerCardTwo(String secondPlayerCard){
+        this.playerCardTwo=secondPlayerCard;
+    }
+}

--- a/src/main/java/interface_adapter/freePlay/setup/SetupViewModel.java
+++ b/src/main/java/interface_adapter/freePlay/setup/SetupViewModel.java
@@ -1,0 +1,18 @@
+package interface_adapter.freeplay.setup;
+
+import interface_adapter.ViewModel;
+
+public class SetupViewModel extends ViewModel<SetupState> {
+    public String DEALER_ONE;
+    public String DEALER_TWO;
+    public String PLAYER_ONE;
+    public String PLAYER_TWO;
+
+    public SetupViewModel() {
+        super("setup");
+        DEALER_ONE = this.getState().getDealerCardOne();
+        DEALER_TWO = this.getState().getDealerCardTwo();
+        PLAYER_ONE = this.getState().getPlayerCardOne();
+        PLAYER_TWO = this.getState().getPlayerCardTwo();
+    }
+}

--- a/src/main/java/use_case/freeplay/setup/SetupInputBoundary.java
+++ b/src/main/java/use_case/freeplay/setup/SetupInputBoundary.java
@@ -10,4 +10,10 @@ public interface SetupInputBoundary {
      */
 
     void execute();
+
+    void switchToHitView();
+
+    void switchToDealerAfterStandView();
+
+    void switchToMainMenuView();
 }

--- a/src/main/java/use_case/freeplay/setup/SetupInteractor.java
+++ b/src/main/java/use_case/freeplay/setup/SetupInteractor.java
@@ -59,4 +59,19 @@ public class SetupInteractor implements SetupInputBoundary {
         final SetupOutputData setupOutputData = new SetupOutputData(dealerHandLinks, userPlayerHandLinks);
         setupPresenter.prepareSuccessView(setupOutputData);
     }
+
+    @Override
+    public void switchToHitView() {
+        setupPresenter.switchToHitView();
+    }
+
+    @Override
+    public void switchToDealerAfterStandView() {
+        setupPresenter.switchToDealerAfterStandView();
+    }
+
+    @Override
+    public void switchToMainMenuView() {
+        setupPresenter.switchToMainMenuView();
+    }
 }

--- a/src/main/java/use_case/freeplay/setup/SetupOutputBoundary.java
+++ b/src/main/java/use_case/freeplay/setup/SetupOutputBoundary.java
@@ -13,4 +13,10 @@ public interface SetupOutputBoundary {
      * @param errorMessage the explanation of the failure
      */
     void prepareFailView(String errorMessage);
+
+    void switchToHitView();
+
+    void switchToDealerAfterStandView();
+
+    void switchToMainMenuView();
 }

--- a/src/main/java/view/MainMenuView.java
+++ b/src/main/java/view/MainMenuView.java
@@ -1,6 +1,8 @@
 package view;
 
 import interface_adapter.freePlay.FreePlayController;
+import interface_adapter.freeplay.setup.SetupController;
+import interface_adapter.learn_mode.LearnModeController;
 import interface_adapter.main_menu.MainMenuState;
 import interface_adapter.main_menu.MainMenuViewModel;
 
@@ -18,8 +20,8 @@ public class MainMenuView extends JPanel implements ActionListener, PropertyChan
 
     //TODO Locate all other controllers accessible from Main Menu as attributes
     private AssistedController assistedController;
-    private FreePlayController freePlayController;
-    private LearnController learnController;
+    private SetupController setupController;
+    private LearnModeController learnController;
     private LogoutController logoutController;
 
     private final JLabel username;
@@ -75,7 +77,7 @@ public class MainMenuView extends JPanel implements ActionListener, PropertyChan
         freePlay.addActionListener(
                 evt -> {
                     if (evt.getSource().equals(freePlay)) {
-                        this.freePlayController.execute();
+                        this.setupController.execute_setup();
                     }
                 }
         );
@@ -115,8 +117,8 @@ public class MainMenuView extends JPanel implements ActionListener, PropertyChan
         this.assistedController = assistedController;
     }
 
-    public void setFreePlayController(FreePlayController freePlayController) {
-        this.freePlayController = freePlayController;
+    public void setSetupController(FreePlayController setupController) {
+        this.setupController = setupController;
     }
 
     public void setLogoutController(LogoutController logoutController) {

--- a/src/main/java/view/SetupView.java
+++ b/src/main/java/view/SetupView.java
@@ -1,0 +1,161 @@
+package view;
+
+import interface_adapter.freeplay.FreePlayController;
+import interface_adapter.freeplay.hit.HitViewModel;
+import interface_adapter.freeplay.setup.SetupController;
+import interface_adapter.freeplay.setup.SetupState;
+import interface_adapter.freeplay.setup.SetupViewModel;
+import interface_adapter.learn_mode.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import static interface_adapter.probability.ProbabilityColourConstants.TABLECOLOUR;
+
+public class SetupView extends JPanel implements ActionListener, PropertyChangeListener {
+    private SetupController setupController;
+
+    public SetupView(SetupViewModel setupViewModel, HitViewModel hitViewModel) {
+        setupViewModel.addPropertyChangeListener(this);
+        hitViewModel.addPropertyChangeListener(this);
+
+        setBackground(TABLECOLOUR);
+
+        this.setLayout(new BorderLayout());
+        Font font = new Font("Times New Roman", Font.BOLD, 15);
+
+        Panel northPanel = new Panel(new BorderLayout());
+
+        // This button should go back to the main menu view
+        JButton mainMenuButton = new JButton("MAIN MENU");
+        mainMenuButton.setFont(font);
+        mainMenuButton.setSize(40, 20);
+        northPanel.add(mainMenuButton, BorderLayout.LINE_START);
+
+        add(northPanel, BorderLayout.NORTH);
+
+        JPanel movesPanel = new JPanel();
+        movesPanel.setLayout(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+
+        // HIT BUTTON
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        constraints.gridwidth = 1;
+        JButton hitButton = new JButton("Hit");
+        hitButton.setFont(font);
+        hitButton.setSize(40, 30);
+        movesPanel.add(hitButton, constraints);
+        // HIT BUTTON ACTION LISTENER
+        hitButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setupController.switchToHitView();
+            }
+        });
+
+        // STAND BUTTON
+        constraints.gridx = 0;
+        constraints.gridy = 1;
+        JButton standButton = new JButton("Stand");
+        standButton.setFont(font);
+        movesPanel.add(standButton, constraints);
+        // STAND BUTTON ACTION LISTENER
+        standButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setupController.switchToDealerAfterStandView();
+            }
+        });
+
+        // QUIT BUTTON
+        constraints.gridx = 0;
+        constraints.gridy = 2;
+        JButton quitGameButton = new JButton("Quit");
+        quitGameButton.setFont(font);
+        movesPanel.setBackground(TABLECOLOUR);
+        movesPanel.add(quitGameButton, constraints);
+        // QUIT BUTTON ACTION LISTENER
+        quitGameButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setupController.switchToMainMenuView();
+            }
+        });
+
+
+        setupController.execute_setup();
+        String dealer_card_one_URL = setupViewModel.DEALER_ONE;
+        String dealer_card_two_URL = setupViewModel.DEALER_TWO;
+        String player_card_one_URL = setupViewModel.PLAYER_ONE;
+        String player_card_two_URL = setupViewModel.PLAYER_TWO;
+        // add code to display image URLs here
+
+
+//        JPanel playerScorePanel = new JPanel(new FlowLayout());
+//        playerScorePanel.setBackground(TABLECOLOUR);
+//
+//        JLabel playerScoreLabel =
+//                new JLabel("<html><font color = 'white'>Your Score: " + outputData + "</font></html>");
+//        playerScoreLabel.setFont(new Font("Times New Roman", Font.BOLD, 25));
+//        playerScoreLabel.setSize(50, 100);
+//
+//        playerScorePanel.add(playerScoreLabel);
+//
+//        add(playerScorePanel, BorderLayout.SOUTH);
+//
+//        JPanel cardPanel = new JPanel(new BorderLayout());
+//        cardPanel.setBackground(TABLECOLOUR);
+//
+//        JPanel playerPanel = new JPanel(new FlowLayout());
+//        playerPanel.setBackground(TABLECOLOUR);
+//
+//        // Build the viewing of the Players Hand
+//        for (String card : playerCards) {
+//            try {
+//                URL imageUrl = new URL(card);
+//                BufferedImage image = ImageIO.read(imageUrl);
+//                ImageIcon icon = new ImageIcon(image);
+//                JLabel imageLabel = new JLabel(icon);
+//
+//                playerPanel.add(imageLabel);
+//            } catch (IOException e) {
+//                e.printStackTrace();
+//                JLabel errorLabel = new JLabel("Failed to load image.");
+//                errorLabel.setHorizontalAlignment(SwingConstants.CENTER);
+//                cardPanel.add(errorLabel, BorderLayout.CENTER);
+//            }
+//
+//        }
+//
+//        // Build the viewing of the dealers (flipped) hand.
+//        JPanel dealerPanel = new FlippedDealerCards(dealerCards);
+//
+//        cardPanel.add(playerPanel, BorderLayout.SOUTH);
+//        cardPanel.add(dealerPanel, BorderLayout.NORTH);
+//
+//        add(cardPanel, BorderLayout.CENTER);
+//
+//        movesPanel.setBounds(810, 100, 230, 50);
+//        add(movesPanel, BorderLayout.LINE_START);
+//
+//    }
+
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        final SetupState state = (SetupState) evt.getNewValue();
+        JOptionPane.showMessageDialog(this, "Setup state change.");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        JOptionPane.showMessageDialog(this, "Cancel not implemented yet.");
+    }
+
+}


### PR DESCRIPTION
**Note: Used Matt's code from FreePlayView in SetupView for all styling and basic GUI layout stuff.**

**What this code does:**
- When user presses "Free Play Mode" on the main menu, it executes the setup use case for this mode 
- The initial setup has two cards each for dealer and player
- When they press hit, it switches to HitView (TODO for me)
- When they press stand, it switches to DealerAfterStandView (by Matt)
- When they press quit, it takes them back to MainMenuView

**Basic Method:**
The image links for the dealer and player's hands were generated in setup interactor by andriy. I added a lot of code in interface adapters and SetupView for these to be displayed. It's hard to explain what I did concisely, but ask me if you have questions on anything!